### PR TITLE
Removing mention of "when" from actions

### DIFF
--- a/docs/saofile.md
+++ b/docs/saofile.md
@@ -59,7 +59,6 @@ __Type__: `Action[]` | `(this: Generator) => Action[] | Promise<Action[]>`
 `actions` is used to manipulate files. There're 4 kinds of actions which share following options:
 
 - __type__: Action type
-- __when__: Similar to `prompts`'s [`when`](#when).
 
 ### `type: 'add'`
 


### PR DESCRIPTION
I don't think `when` is actually implemented on actions from what I can see.